### PR TITLE
Update gmap.inverted.circle.js - getBounds

### DIFF
--- a/lib/gmap.inverted.circle.js
+++ b/lib/gmap.inverted.circle.js
@@ -229,6 +229,15 @@ InvertedCircle.prototype.getBounds = function()
     up_bound = google.maps.geometry.spherical.computeOffset(center, bound_radius, 360);
     down_bound = google.maps.geometry.spherical.computeOffset(center, bound_radius, 180);
   }
+  
+  if(old_radius == radius){
+    console.log('old_radius == radius');
+   // bound_radius = radius;
+    left_bound = google.maps.geometry.spherical.computeOffset(center, bound_radius, -90);
+    right_bound = google.maps.geometry.spherical.computeOffset(center, bound_radius, 90);
+    up_bound = google.maps.geometry.spherical.computeOffset(center, bound_radius, 360);
+    down_bound = google.maps.geometry.spherical.computeOffset(center, bound_radius, 180);
+  }
 
   /*console.log(left_bound);
     console.log(right_bound);


### PR DESCRIPTION
A fix for error "Cannot call method 'lat' of undefined", when calling the getBounds function without resizing circle.
